### PR TITLE
msm8916-common: Allow rmt_storage to use dac_override, net_raw capabi…

### DIFF
--- a/sepolicy/rmt_storage.te
+++ b/sepolicy/rmt_storage.te
@@ -1,0 +1,1 @@
+allow rmt_storage self:capability { dac_override net_raw };


### PR DESCRIPTION
…lities

Change-Id: Ie5e567c96278711ca5c84258ecb4602aa2fafcc3